### PR TITLE
Fix url encoding: Twitter requires uppercase hex characters after %

### DIFF
--- a/toolkit.lisp
+++ b/toolkit.lisp
@@ -117,7 +117,7 @@ According to spec https://dev.twitter.com/docs/auth/percent-encoding-parameters"
                         (char<= #\A char #\Z)
                         (find char "-._~" :test #'char=))
                     (write-char char out))
-                   (t (format out "%~2,'0x" (char-code char)))))))
+                   (t (format out "~:@(%~2,'0x~)" (char-code char)))))))
 
 (defun xml-decode (string)
   "Transforms &lt; &gt; &amp; into their proper characters."


### PR DESCRIPTION
Depending on the Lisp implementation, ~x output hex digits in lowercase (e.g. Allegro) or uppercase (e.g. SBCL).

It must be forced uppercase according to https://dev.twitter.com/oauth/overview/percent-encoding-parameters otherwise the request fails:
  ```
OAuth Request Failed: Status code 401 when requesting https://api.twitter.com/oauth/request_token :
((:ERRORS ((:MESSAGE . "Could not authenticate you.") (:CODE . 32))))
```