### PR TITLE
geo/search API query now returns application/octet-stream content-type

### DIFF
--- a/drakma.lisp
+++ b/drakma.lisp
@@ -7,7 +7,7 @@
 (in-package #:org.tymoonnext.chirp)
 
 (defun perform-request (uri &rest params)
-  (let ((drakma:*text-content-types* (cons '("application" . "json") (cons '("text" . "json") drakma:*text-content-types*))))
+  (let ((drakma:*text-content-types* (cons '("application" . "octet-stream") (cons '("application" . "json") (cons '("text" . "json") drakma:*text-content-types*)))))
     (multiple-value-list (apply #'drakma:http-request uri
                                 :external-format-in *external-format*
                                 :external-format-out *external-format*

--- a/oauth.lisp
+++ b/oauth.lisp
@@ -109,7 +109,9 @@ Simply generates a signature and appends the proper parameter."
 
 (defun parse-body (body headers)
   (let ((type (cdr (assoc :content-type headers))))
-    (cond ((search "application/json" type)
+    (cond ((or
+             (search "application/json" type)
+             (search "application/octet-stream" type))
            (yason:parse body :object-as :alist :object-key-fn #'to-keyword))
           ((or (search "text/plain" type)
                (search "text/html" type))


### PR DESCRIPTION
so allow parse-body to turn the returned json in an alist

this threw an error before
(chirp:geo/search :latitude 40.033 :longitude -83.158 :granularity :NEIGHBORHOOD :max-results 10)

and now it does not

https://developer.twitter.com/en/docs/geo/places-near-location/api-reference/get-geo-search