### PR TITLE
Tweet mode: extended

### DIFF
--- a/favorites.lisp
+++ b/favorites.lisp
@@ -10,13 +10,13 @@
 (defvar *favorites/destroy* "https://api.twitter.com/1.1/favorites/destroy.json")
 (defvar *favorites/create* "https://api.twitter.com/1.1/favorites/create.json")
 
-(defun favorites/list (&key user-id screen-name (count 20) since-id max-id (include-entities T))
+(defun favorites/list (&key user-id screen-name (count 20) since-id max-id (include-entities T) (tweet_mode "extended"))
   "Returns the 20 most recent Tweets favorited by the authenticating or specified user.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/favorites/list"
   (assert (<= count 200) () "COUNT must be less than or equal to 200.")
   (unless include-entities (setf include-entities "false"))
-  (mapcar #'make-status (signed-request *favorites/list* :parameters (prepare* user-id screen-name count since-id max-id include-entities) :method :GET)))
+  (mapcar #'make-status (signed-request *favorites/list* :parameters (prepare* user-id screen-name count since-id max-id include-entities tweet_mode) :method :GET)))
 
 (defun favorites/destroy (id &key (include-entities T))
   "Un-favorites the status specified in the ID parameter as the authenticating user. Returns the un-favorited status in the requested format when successful.

--- a/lists.lisp
+++ b/lists.lisp
@@ -48,13 +48,13 @@
 According to spec https://dev.twitter.com/docs/api/1.1/get/lists/list"
   (mapcar #'make-user-list (signed-request *lists/list* :parameters (prepare* user-id screen-name reverse) :method :GET)))
 
-(defun lists/statuses (&key list-id slug owner-screen-name owner-id since-id max-id (count 20) (include-entities T) include-rts)
+(defun lists/statuses (&key list-id slug owner-screen-name owner-id since-id max-id (count 20) (include-entities T) include-rts (tweet_mode "extended"))
   "Returns a timeline of tweets authored by members of the specified list. Retweets are included by default. Use the include_rts=false parameter to omit retweets.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/lists/statuses"
   (assert (or list-id (and slug (or owner-screen-name owner-id))) () "Either LIST-ID or SLUG and OWNER-SCREEN-NAME or OWNER-ID are required.")
   (unless include-entities (setf include-entities "false"))
-  (mapcar #'make-status (signed-request *lists/statuses* :parameters (prepare* list-id slug owner-screen-name owner-id since-id max-id count include-entities include-rts) :method :GET)))
+  (mapcar #'make-status (signed-request *lists/statuses* :parameters (prepare* list-id slug owner-screen-name owner-id since-id max-id count include-entities include-rts tweet_mode) :method :GET)))
 
 (defun lists/show (&key list-id slug owner-screen-name owner-id)
   "Returns the specified list. Private lists will only be shown if the authenticated user owns the specified list.

--- a/package.lisp
+++ b/package.lisp
@@ -38,6 +38,7 @@
    #:direct-message
    #:id
    #:text
+   #:full-text
    #:recipient
    #:sender
    #:created-at

--- a/search.lisp
+++ b/search.lisp
@@ -20,7 +20,7 @@
 (define-make-* (search-metadata)
   :max-id :since-id :refresh-url :next-results (:result-count . :count) :completed-in :query)
 
-(defun search/tweets (query &key latitude longitude radius locale language (result-type :mixed) (count 15) until since-id max-id (include-entities T))
+(defun search/tweets (query &key latitude longitude radius locale language (result-type :mixed) (count 15) until since-id max-id (include-entities T) (tweet_mode "extended"))
   "Returns a collection of relevant Tweets matching a specified query and some search metadata as a second value.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/search/tweets"
@@ -36,7 +36,7 @@ According to spec https://dev.twitter.com/docs/api/1.1/get/search/tweets"
   (unless include-entities (setf include-entities "false"))
   (let* ((geocode (when latitude (format NIL "~a,~a,~a" latitude longitude radius)))
          (data (signed-request *search/tweets*
-                               :parameters (prepare* (q . query) geocode locale language result-type count until since-id max-id include-entities)
+                               :parameters (prepare* (q . query) geocode locale language result-type count until since-id max-id include-entities tweet_mode)
                                :method :GET)))
     (values (mapcar #'make-status (cdr (assoc :statuses data)))
             (make-search-metadata (cdr (assoc :search-metadata data))))))

--- a/statuses.lisp
+++ b/statuses.lisp
@@ -65,12 +65,12 @@ According to spec https://dev.twitter.com/docs/platform-objects/tweets"))
   :author-name :author-url :provider-url :provider-name
   (:cache-age (parse-when-param :cache-age #'local-time:unix-to-timestamp)))
 
-(defun statuses/retweets (id &key (count 100) trim-user)
+(defun statuses/retweets (id &key (count 100) trim-user (tweet_mode "extended"))
   "Returns a collection of the 100 most recent retweets of the tweet specified by the id parameter.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/retweets/%3Aid"
   (assert (<= count 100) () "Count must be less than or equal to 100.")
-  (mapcar #'make-status (signed-request (format NIL *statuses/retweets* id) :parameters (prepare* count trim-user) :method :GET)))
+  (mapcar #'make-status (signed-request (format NIL *statuses/retweets* id) :parameters (prepare* count trim-user tweet_mode) :method :GET)))
 
 (defun statuses/show (id &key trim-user include-my-retweet (include-entities T) (tweet_mode "extended"))
   "Returns a single Tweet, specified by the id parameter. The Tweet's author will also be embedded within the tweet.

--- a/statuses.lisp
+++ b/statuses.lisp
@@ -16,7 +16,7 @@
 (defvar *statuses/retweeters/ids* "https://api.twitter.com/1.1/statuses/retweeters/ids.json")
 
 (defclass* status ()
-  (id text entities created-at
+  (id text full-text entities created-at
    user contributors source
    coordinates place
    retweeted-status filter-level scopes
@@ -37,7 +37,7 @@ According to spec https://dev.twitter.com/docs/platform-objects/tweets"))
   status)
 
 (define-make-* (status parameters)
-  :id :text :source :filter-level :scopes
+  :id :text :full-text :source :filter-level :scopes
   :possibly-sensitive :retweeted :favorited :truncated
   :withheld-copyright :withheld-in-countries :withheld-scope
   (:counts `((:favorites . ,(cdr (assoc :favorite-count parameters)))
@@ -72,12 +72,12 @@ According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/retweets/%3A
   (assert (<= count 100) () "Count must be less than or equal to 100.")
   (mapcar #'make-status (signed-request (format NIL *statuses/retweets* id) :parameters (prepare* count trim-user) :method :GET)))
 
-(defun statuses/show (id &key trim-user include-my-retweet (include-entities T))
+(defun statuses/show (id &key trim-user include-my-retweet (include-entities T) (tweet_mode "extended"))
   "Returns a single Tweet, specified by the id parameter. The Tweet's author will also be embedded within the tweet.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/show/%3Aid"
   (unless include-entities (setf include-entities "false"))
-  (make-status (signed-request (format NIL *statuses/show* id) :parameters (prepare* trim-user include-my-retweet include-entities) :method :GET)))
+  (make-status (signed-request (format NIL *statuses/show* id) :parameters (prepare* trim-user include-my-retweet include-entities tweet_mode) :method :GET)))
 
 (defun statuses/destroy (id &key trim-user)
   "Destroys the status specified by the required ID parameter. The authenticating user must be the author of the specified status. Returns the destroyed status if successful.

--- a/timelines.lisp
+++ b/timelines.lisp
@@ -11,14 +11,14 @@
 (defvar *statuses/home-timeline* "https://api.twitter.com/1.1/statuses/home_timeline.json")
 (defvar *statuses/retweets-of-me* "https://api.twitter.com/1.1/statuses/retweets_of_me.json")
 
-(defun statuses/mentions-timeline (&key (count 20) since-id max-id trim-user (include-entities T) contributor-details)
+(defun statuses/mentions-timeline (&key (count 20) since-id max-id trim-user (include-entities T) contributor-details (tweet_mode "extended"))
   "Returns the 20 most recent mentions (tweets containing a users's @screen_name) for the authenticating user.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/mentions_timeline"
   (assert (<= count 200) () "COUNT cannot be higher than 200.")
   (unless include-entities (setf include-entities "false"))
   (mapcar #'make-status (signed-request *statuses/mentions-timeline*
-                                        :parameters (prepare* count since-id max-id trim-user include-entities contributor-details)
+                                        :parameters (prepare* count since-id max-id trim-user include-entities contributor-details tweet_mode)
                                         :method :GET)))
 
 (defun statuses/user-timeline (&key user-id screen-name (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details (include-rts T) (tweet_mode "extended"))
@@ -33,17 +33,17 @@ According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/user_timelin
                                         :parameters (prepare* user-id screen-name count since-id max-id trim-user exclude-replies include-entities contributor-details include-rts tweet_mode)
                                         :method :GET)))
 
-(defun statuses/home-timeline (&key (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details)
+(defun statuses/home-timeline (&key (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details (tweet_mode "extended"))
   "Returns a collection of the most recent Tweets and retweets posted by the authenticating user and the users they follow. The home timeline is central to how most users interact with the Twitter service.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/home_timeline"
   (assert (<= count 200) () "Count cannot be higher than 200.")
   (unless include-entities (setf include-entities "false"))
   (mapcar #'make-status (signed-request *statuses/home-timeline*
-                                        :parameters (prepare* count since-id max-id trim-user exclude-replies include-entities contributor-details)
+                                        :parameters (prepare* count since-id max-id trim-user exclude-replies include-entities contributor-details tweet_mode)
                                         :method :GET)))
 
-(defun statuses/retweets-of-me (&key (count 20) since-id max-id trim-user (include-entities T) (include-user-entities T))
+(defun statuses/retweets-of-me (&key (count 20) since-id max-id trim-user (include-entities T) (include-user-entities T) (tweet_mode "extended"))
   "Returns the most recent tweets authored by the authenticating user that have been retweeted by others. This timeline is a subset of the user's GET statuses/user_timeline.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/retweets_of_me"
@@ -51,5 +51,5 @@ According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/retweets_of_
   (unless include-entities (setf include-entities "false"))
   (unless include-user-entities (setf include-user-entities "false"))
   (mapcar #'make-status (signed-request *statuses/retweets-of-me*
-                                        :parameters (prepare* count since-id max-id trim-user include-entities include-user-entities)
+                                        :parameters (prepare* count since-id max-id trim-user include-entities include-user-entities tweet_mode)
                                         :method :GET)))

--- a/timelines.lisp
+++ b/timelines.lisp
@@ -21,7 +21,7 @@ According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/mentions_tim
                                         :parameters (prepare* count since-id max-id trim-user include-entities contributor-details)
                                         :method :GET)))
 
-(defun statuses/user-timeline (&key user-id screen-name (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details (include-rts T))
+(defun statuses/user-timeline (&key user-id screen-name (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details (include-rts T) (tweet_mode "extended"))
   "Returns a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline"
@@ -30,7 +30,7 @@ According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/user_timelin
   (unless include-rts (setf include-rts "false"))
   (unless include-entities (setf include-entities "false"))
   (mapcar #'make-status (signed-request *statuses/user-timeline*
-                                        :parameters (prepare* user-id screen-name count since-id max-id trim-user exclude-replies include-entities contributor-details include-rts)
+                                        :parameters (prepare* user-id screen-name count since-id max-id trim-user exclude-replies include-entities contributor-details include-rts tweet_mode)
                                         :method :GET)))
 
 (defun statuses/home-timeline (&key (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details)


### PR DESCRIPTION
currently statuses are returned with only 140 characters.
if more characters are in the status then the slot "text" in the status object will be truncated and the slot "truncated" will be true.

this PR adds a "full-text" slot to the status class and requests the "extended_tweet" mode which will return all characters. 
https://developer.twitter.com/en/docs/tweets/tweet-updates


NOTE:
"extended_tweet" also returns a few more payload fields (in addition to full_text) that this PR does not make use of:
    display_text_range
    extended_entities
