### PR TITLE
Implemented support for extended tweets.

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -194,6 +194,8 @@
    #:status
    #:id
    #:text
+   #:full-text
+   #:display-text-range
    #:entities
    #:created-at
    #:user

--- a/statuses.lisp
+++ b/statuses.lisp
@@ -16,7 +16,7 @@
 (defvar *statuses/retweeters/ids* "https://api.twitter.com/1.1/statuses/retweeters/ids.json")
 
 (defclass* status ()
-  (id text entities created-at
+  (id text full-text display-text-range entities created-at
    user contributors source
    coordinates place
    retweeted-status filter-level scopes
@@ -37,7 +37,7 @@ According to spec https://dev.twitter.com/docs/platform-objects/tweets"))
   status)
 
 (define-make-* (status parameters)
-  :id :text :source :filter-level :scopes
+  :id :text :full-text :display-text-range :source :filter-level :scopes
   :possibly-sensitive :retweeted :favorited :truncated
   :withheld-copyright :withheld-in-countries :withheld-scope
   (:counts `((:favorites . ,(cdr (assoc :favorite-count parameters)))
@@ -65,12 +65,12 @@ According to spec https://dev.twitter.com/docs/platform-objects/tweets"))
   :author-name :author-url :provider-url :provider-name
   (:cache-age (parse-when-param :cache-age #'local-time:unix-to-timestamp)))
 
-(defun statuses/retweets (id &key (count 100) trim-user)
+(defun statuses/retweets (id &key (count 100) trim-user tweet-mode)
   "Returns a collection of the 100 most recent retweets of the tweet specified by the id parameter.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/retweets/%3Aid"
   (assert (<= count 100) () "Count must be less than or equal to 100.")
-  (mapcar #'make-status (signed-request (format NIL *statuses/retweets* id) :parameters (prepare* count trim-user) :method :GET)))
+  (mapcar #'make-status (signed-request (format NIL *statuses/retweets* id) :parameters (prepare* count trim-user tweet-mode) :method :GET)))
 
 (defun statuses/show (id &key trim-user include-my-retweet (include-entities T))
   "Returns a single Tweet, specified by the id parameter. The Tweet's author will also be embedded within the tweet.

--- a/timelines.lisp
+++ b/timelines.lisp
@@ -11,17 +11,17 @@
 (defvar *statuses/home-timeline* "https://api.twitter.com/1.1/statuses/home_timeline.json")
 (defvar *statuses/retweets-of-me* "https://api.twitter.com/1.1/statuses/retweets_of_me.json")
 
-(defun statuses/mentions-timeline (&key (count 20) since-id max-id trim-user (include-entities T) contributor-details)
+(defun statuses/mentions-timeline (&key (count 20) since-id max-id trim-user (include-entities T) contributor-details tweet-mode)
   "Returns the 20 most recent mentions (tweets containing a users's @screen_name) for the authenticating user.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/mentions_timeline"
   (assert (<= count 200) () "COUNT cannot be higher than 200.")
   (unless include-entities (setf include-entities "false"))
   (mapcar #'make-status (signed-request *statuses/mentions-timeline*
-                                        :parameters (prepare* count since-id max-id trim-user include-entities contributor-details)
+                                        :parameters (prepare* count since-id max-id trim-user include-entities contributor-details tweet-mode)
                                         :method :GET)))
 
-(defun statuses/user-timeline (&key user-id screen-name (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details (include-rts T))
+(defun statuses/user-timeline (&key user-id screen-name (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details (include-rts T) tweet-mode)
   "Returns a collection of the most recent Tweets posted by the user indicated by the screen_name or user_id parameters.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline"
@@ -30,20 +30,20 @@ According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/user_timelin
   (unless include-rts (setf include-rts "false"))
   (unless include-entities (setf include-entities "false"))
   (mapcar #'make-status (signed-request *statuses/user-timeline*
-                                        :parameters (prepare* user-id screen-name count since-id max-id trim-user exclude-replies include-entities contributor-details include-rts)
+                                        :parameters (prepare* user-id screen-name count since-id max-id trim-user exclude-replies include-entities contributor-details include-rts tweet-mode)
                                         :method :GET)))
 
-(defun statuses/home-timeline (&key (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details)
+(defun statuses/home-timeline (&key (count 20) since-id max-id trim-user exclude-replies (include-entities T) contributor-details tweet-mode)
   "Returns a collection of the most recent Tweets and retweets posted by the authenticating user and the users they follow. The home timeline is central to how most users interact with the Twitter service.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/home_timeline"
   (assert (<= count 200) () "Count cannot be higher than 200.")
   (unless include-entities (setf include-entities "false"))
   (mapcar #'make-status (signed-request *statuses/home-timeline*
-                                        :parameters (prepare* count since-id max-id trim-user exclude-replies include-entities contributor-details)
+                                        :parameters (prepare* count since-id max-id trim-user exclude-replies include-entities contributor-details tweet-mode)
                                         :method :GET)))
 
-(defun statuses/retweets-of-me (&key (count 20) since-id max-id trim-user (include-entities T) (include-user-entities T))
+(defun statuses/retweets-of-me (&key (count 20) since-id max-id trim-user (include-entities T) (include-user-entities T) tweet-mode)
   "Returns the most recent tweets authored by the authenticating user that have been retweeted by others. This timeline is a subset of the user's GET statuses/user_timeline.
 
 According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/retweets_of_me"
@@ -51,5 +51,5 @@ According to spec https://dev.twitter.com/docs/api/1.1/get/statuses/retweets_of_
   (unless include-entities (setf include-entities "false"))
   (unless include-user-entities (setf include-user-entities "false"))
   (mapcar #'make-status (signed-request *statuses/retweets-of-me*
-                                        :parameters (prepare* count since-id max-id trim-user include-entities include-user-entities)
+                                        :parameters (prepare* count since-id max-id trim-user include-entities include-user-entities tweet-mode)
                                         :method :GET)))


### PR DESCRIPTION
Added the keyword argument :tweet-mode to function receiving tweets.
This keyword can be used to get "extended" tweets by passing it the
string "extended". See [1] for documentation.

  [1] https://developer.twitter.com/en/docs/tweets/tweet-updates